### PR TITLE
Curated Offshore data integration

### DIFF
--- a/data/raw/offshore_wind_locations.csv
+++ b/data/raw/offshore_wind_locations.csv
@@ -1,0 +1,51 @@
+﻿City,State,County,County FIPS,Why of interest?,Priority,Cable landing(s),Assembly/manufacturing,Notes,location_id,Cable project IDs,assembly/manufac project IDs
+Albany,NY,Albany County,36001,Contracted project,,,Beacon Wind,,1,,16
+Atlantic City,NJ,Atlantic County,34001,Contracted project,,Atlantic Shores,Ocean Wind  1 & 2,,2,15,6
+Barnstable,MA,Barnstable County,25001,Contracted project,,"Vineyard Wind,Commonwealth Wind,Park City Wind",,,3,"3, 1, 9",
+Beaumont,TX,Jefferson County,48245,Proposed lease area,,,,,4,,
+Bridgeport,CT,Fairfield County,09001,Contracted project,,,Park City Wind,,5,,9
+Brookhaven,NY, Suffolk County,36103,Contracted project,,Sunrise Wind,,,6,8,
+Brookings,OR,Curry County,41015,Proposed lease area,,,,,7,,
+Brooklyn,NY,Kings County,36047,Contracted project,,Empire Wind 1 & 2,"Empire Wind 1 & 2,Beacon Wind",,8,12,"12, 16"
+Coeymans,NY,Albany County,36001,Contracted project,,,Sunrise Wind,,9,,8
+Coos Bay,OR,Coos County,41011,Proposed lease area,,,,,10,,
+Dagsboro,DE,Sussex County,10005,Contracted project,,"Skipjack Wind 1 & 2,Marwin,Momentum Wind",,,11,"13, 14, 11",
+Dare County,NC,Dare County,37055,Lease area in proximity,,Kitty Hawk Offshore,,,12,2,
+East Hampton,NY, Suffolk County,36103,Contracted project,,South Fork Wind Farm,,,13,4,
+Eureka,CA,Humboldt County,06023,Proposed lease area,,,,,14,,
+Falmouth,MA,Barnstable County,25001,Contracted project,,Mayflower Wind,,,15,7,
+Federalsburg,MD,Caroline County,24011,Contracted project,,,Skipjack Wind 1 & 2,,16,,13
+Forked River,NJ,Ocean County,34029,Contracted project,,Ocean Wind  1 & 2,,,17,6,
+Freeport,TX,Brazoria,48039,Proposed lease area,,,,,18,,
+Galveston,TX,Galveston County,48167,Proposed lease area,,,,,19,,
+Hampton Roads,VA,,,Contracted project,,,Coastal Virginia Offshore Wind ,,20,,10
+Houston,TX,Harris County,48201,Proposed lease area,,,,,21,,
+Kitty Hawk,NC,Dare County,37055,Lease area in proximity,,,,,22,,
+Lake Charles,LA,Calcasieu Parish,22019,Proposed lease area,,,,,23,,
+Lower Alloways Creek,NJ,Salem County,34033,Contracted project,,,"Ocean Wind  1 & 2,Atlantic Shores",,24,,"6, 15"
+Montauk,NY, Suffolk County,36103,Contracted project,,,South Fork Wind Farm,,25,,4
+Morro Bay,CA,San Luis Obispo County ,06079,Proposed lease area,,,,,26,,
+Myrtle Beach,SC,Horry County,45051,Lease area in proximity,,,,,27,,
+New Bedford,MA,Bristol County,25005,Contracted project,,,"Vineyard Wind,Mayflower Wind",,28,,"3, 7"
+New London,CT,New London County,09011,Contracted project,,,"Revolution Wind,South Fork Wind Farm,Sunrise Wind",,29,,"5, 4, 8"
+North Kingstown,RI,Washington County,44009,Contracted project,,Revolution Wind,Revolution Wind,,30,5,5
+Ocean City,NJ,Cape May,34009,Contracted project,,Ocean Wind  1 & 2,,,31,6,
+Ocean City,MD,Worcester,24047,Contracted project,,,"Marwin,Momentum Wind",,32,,"14, 11"
+Oceanside,NY,Nassau County,36059,Contracted project,,Empire Wind 1 & 2,,,33,12,
+Orange,TX,Orange County,48361,Proposed lease area,,,,,34,,
+Paulsboro,NJ,Gloucester County,34015,Contracted project,,,"Ocean Wind  1 & 2,Atlantic Shores",,35,,"6, 15"
+Port Arthur,TX,Jefferson County,48245,Proposed lease area,,,,,36,,
+Port Jefferson,NY, Suffolk County,36103,Contracted project,,,Sunrise Wind,,37,,8
+Portsmouth,VA,Portsmouth City,51740,Proposed lease area,,,,,38,,
+Providence,RI,Providence County,44007,Contracted project,,,Revolution Wind,,39,,5
+Queens,NY,Queens County,36081,Contracted project,,Beacon Wind,,,40,16,
+Rehoboth Beach,DE,Sussex County,10005,Contracted project,,"Skipjack Wind 1 & 2,Marwin,Momentum Wind",,,41,"13, 14, 11",
+Salem,MA,Essex,25009,Contracted project,,,"Vineyard Wind,Commonwealth Wind,Park City Wind",,42,,"3, 1, 9"
+Sea Girt,NJ,Monmouth County,34025,Contracted project,,Atlantic Shores,,,43,15,
+Seaside Park,NJ,Ocean County,34029,Contracted project,,Ocean Wind  1 & 2,,,44,6,
+Somerset,MA,Bristol County,25005,Contracted project,,Mayflower Wind,Commonwealth Wind,,45,7,1
+Sparrows Point,MD,Baltimore County,24005,Contracted project,,,"Skipjack Wind 1 & 2,Marwin,Momentum Wind",,46,,"13, 14, 11"
+Staten Island,NY,Richmond County,36085,Contracted project,,,Empire Wind 1 & 2,,47,,12
+Texas City,TX,Galveston County,48167,Proposed lease area,,,,,48,,
+Virginia Beach,VA,Virginia Beach City,51810,Contracted project,,"Coastal Virginia Offshore Wind ,Kitty Hawk Offshore",,,49,"10, 2",
+Wilmington,NC,New Hanover,37129,Lease area in proximity,,,,,50,,

--- a/data/raw/offshore_wind_projects.csv
+++ b/data/raw/offshore_wind_projects.csv
@@ -1,0 +1,17 @@
+﻿Name,Recipient State,Developer,Status,Proposed cable landing,County of Cable Landing,Port Locations,Size (megawatts),Online date,Notes,project_id,Cable Location IDs,Port Location IDs
+Commonwealth Wind,MA,Avangrid,Contracted,Barnstable,Barnstable County,"Somerset,Salem",800,,,1,3,"45, 42"
+Kitty Hawk Offshore,TBD,Avangrid,Permitting underway - no contract,"Virginia Beach,Dare County","Dare County, Virginia Beach",,2500,,,2,"49, 12",
+Vineyard Wind,MA,"Avangrid,CIP",Under construction,Barnstable,Barnstable County,"New Bedford,Salem",800,2023,,3,3,"28, 42"
+South Fork Wind Farm,NY,Orsted,Under construction,East Hampton,Suffolk County,"New London,Montauk",132,2023,,4,13,"29, 25"
+Revolution Wind,"RI,CT",Orsted,Contracted,North Kingstown,Washington County,"North Kingstown,Providence,New London",700,2023,,5,30,"30, 39, 29"
+Ocean Wind  1 & 2,NJ,Orsted,Contracted,"Seaside Park,Ocean City,Forked River","Ocean County, Cape May","Paulsboro,Lower Alloways Creek,Atlantic City",2248,2024,,6,"44, 31, 17","35, 24, 2"
+Mayflower Wind,MA,"Shell,EDPR,Engie",Contracted,"Somerset,Falmouth","Bristol County, Barnstable County",New Bedford,1204,2025,,7,"45, 15",28
+Sunrise Wind,NY,Orsted,Contracted,Brookhaven,Suffolk County,"New London,Port Jefferson,Coeymans",924,2025,,8,6,"29, 37, 9"
+Park City Wind,CT,Avangrid,Contracted,Barnstable,Barnstable County,"Bridgeport,Salem",804,2025,,9,3,"5, 42"
+Coastal Virginia Offshore Wind ,VA,Dominion,Contracted,Virginia Beach,Virginia Beach County,Hampton Roads,2600,2026,,10,49,20
+Momentum Wind,MD,US Wind,Contracted,"Rehoboth Beach,Dagsboro",Sussex Couty,"Sparrows Point,Ocean City",809,2026,,11,"41, 11","46, 32"
+Empire Wind 1 & 2,NY,"Equinor,BP",Contracted,"Brooklyn,Oceanside","Kings County, Nassau County","Brooklyn,Staten Island",2076,2026,,12,"8, 33","8, 47"
+Skipjack Wind 1 & 2,MD,Orsted,Contracted,"Rehoboth Beach,Dagsboro",Sussex Couty,"Sparrows Point,Federalsburg",966,2026,,13,"41, 11","46, 16"
+Marwin,MD,US Wind,Contracted,"Rehoboth Beach,Dagsboro",Sussex Couty,"Sparrows Point,Ocean City",248,2026,,14,"41, 11","46, 32"
+Atlantic Shores,NJ,"Shell,EDF",Contracted,"Atlantic City,Sea Girt","Atlantic County, Monmouth County","Paulsboro,Lower Alloways Creek",1510,2028,,15,"2, 43","35, 24"
+Beacon Wind,NY,"Equinor,BP",Contracted,Queens,Queens County,"Brooklyn,Albany",1230,2028,,16,40,"8, 1"

--- a/notebooks/19-tpb-explore_offshore_wind.ipynb
+++ b/notebooks/19-tpb-explore_offshore_wind.ipynb
@@ -1,0 +1,2474 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "65745c26-1102-4a1e-b7e8-9792f5dfa92c",
+   "metadata": {},
+   "source": [
+    "# Offshore Data\n",
+    "This notebook is a preliminary exploration and QC of offshore wind data hosted on airtable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c4bc63a7-81fa-4154-87ae-ca987b8571a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cd208a5d-9493-4a63-bdc2-ecd25de54792",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path_projects = Path('../data/raw/offshore_wind_projects.csv')\n",
+    "assert path_projects.exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "64b3db60-2285-4e67-b240-5b6024f11728",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path_locations = Path('../data/raw/offshore_wind_locations.csv')\n",
+    "assert path_locations.exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a302c059-b33e-4bb8-a370-75c1c4142eb9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Recipient State</th>\n",
+       "      <th>Developer</th>\n",
+       "      <th>Status</th>\n",
+       "      <th>Proposed cable landing</th>\n",
+       "      <th>County of Cable Landing</th>\n",
+       "      <th>Port Locations</th>\n",
+       "      <th>Size (megawatts)</th>\n",
+       "      <th>Online date</th>\n",
+       "      <th>Notes</th>\n",
+       "      <th>Cable Location IDs</th>\n",
+       "      <th>Port Location IDs</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>project_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Commonwealth Wind</td>\n",
+       "      <td>MA</td>\n",
+       "      <td>Avangrid</td>\n",
+       "      <td>Contracted</td>\n",
+       "      <td>Barnstable</td>\n",
+       "      <td>Barnstable County</td>\n",
+       "      <td>Somerset,Salem</td>\n",
+       "      <td>800</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3</td>\n",
+       "      <td>45, 42</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Kitty Hawk Offshore</td>\n",
+       "      <td>TBD</td>\n",
+       "      <td>Avangrid</td>\n",
+       "      <td>Permitting underway - no contract</td>\n",
+       "      <td>Virginia Beach,Dare County</td>\n",
+       "      <td>Dare County, Virginia Beach</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2500</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>49, 12</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Vineyard Wind</td>\n",
+       "      <td>MA</td>\n",
+       "      <td>Avangrid,CIP</td>\n",
+       "      <td>Under construction</td>\n",
+       "      <td>Barnstable</td>\n",
+       "      <td>Barnstable County</td>\n",
+       "      <td>New Bedford,Salem</td>\n",
+       "      <td>800</td>\n",
+       "      <td>2023.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3</td>\n",
+       "      <td>28, 42</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>South Fork Wind Farm</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>Orsted</td>\n",
+       "      <td>Under construction</td>\n",
+       "      <td>East Hampton</td>\n",
+       "      <td>Suffolk County</td>\n",
+       "      <td>New London,Montauk</td>\n",
+       "      <td>132</td>\n",
+       "      <td>2023.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>13</td>\n",
+       "      <td>29, 25</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Revolution Wind</td>\n",
+       "      <td>RI,CT</td>\n",
+       "      <td>Orsted</td>\n",
+       "      <td>Contracted</td>\n",
+       "      <td>North Kingstown</td>\n",
+       "      <td>Washington County</td>\n",
+       "      <td>North Kingstown,Providence,New London</td>\n",
+       "      <td>700</td>\n",
+       "      <td>2023.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>30</td>\n",
+       "      <td>30, 39, 29</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>Ocean Wind  1 &amp; 2</td>\n",
+       "      <td>NJ</td>\n",
+       "      <td>Orsted</td>\n",
+       "      <td>Contracted</td>\n",
+       "      <td>Seaside Park,Ocean City,Forked River</td>\n",
+       "      <td>Ocean County, Cape May</td>\n",
+       "      <td>Paulsboro,Lower Alloways Creek,Atlantic City</td>\n",
+       "      <td>2248</td>\n",
+       "      <td>2024.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>44, 31, 17</td>\n",
+       "      <td>35, 24, 2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>Mayflower Wind</td>\n",
+       "      <td>MA</td>\n",
+       "      <td>Shell,EDPR,Engie</td>\n",
+       "      <td>Contracted</td>\n",
+       "      <td>Somerset,Falmouth</td>\n",
+       "      <td>Bristol County, Barnstable County</td>\n",
+       "      <td>New Bedford</td>\n",
+       "      <td>1204</td>\n",
+       "      <td>2025.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>45, 15</td>\n",
+       "      <td>28</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>Sunrise Wind</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>Orsted</td>\n",
+       "      <td>Contracted</td>\n",
+       "      <td>Brookhaven</td>\n",
+       "      <td>Suffolk County</td>\n",
+       "      <td>New London,Port Jefferson,Coeymans</td>\n",
+       "      <td>924</td>\n",
+       "      <td>2025.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>6</td>\n",
+       "      <td>29, 37, 9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>Park City Wind</td>\n",
+       "      <td>CT</td>\n",
+       "      <td>Avangrid</td>\n",
+       "      <td>Contracted</td>\n",
+       "      <td>Barnstable</td>\n",
+       "      <td>Barnstable County</td>\n",
+       "      <td>Bridgeport,Salem</td>\n",
+       "      <td>804</td>\n",
+       "      <td>2025.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3</td>\n",
+       "      <td>5, 42</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>Coastal Virginia Offshore Wind</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>Dominion</td>\n",
+       "      <td>Contracted</td>\n",
+       "      <td>Virginia Beach</td>\n",
+       "      <td>Virginia Beach County</td>\n",
+       "      <td>Hampton Roads</td>\n",
+       "      <td>2600</td>\n",
+       "      <td>2026.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>49</td>\n",
+       "      <td>20</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>Momentum Wind</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>US Wind</td>\n",
+       "      <td>Contracted</td>\n",
+       "      <td>Rehoboth Beach,Dagsboro</td>\n",
+       "      <td>Sussex Couty</td>\n",
+       "      <td>Sparrows Point,Ocean City</td>\n",
+       "      <td>809</td>\n",
+       "      <td>2026.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>41, 11</td>\n",
+       "      <td>46, 32</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>Empire Wind 1 &amp; 2</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>Equinor,BP</td>\n",
+       "      <td>Contracted</td>\n",
+       "      <td>Brooklyn,Oceanside</td>\n",
+       "      <td>Kings County, Nassau County</td>\n",
+       "      <td>Brooklyn,Staten Island</td>\n",
+       "      <td>2076</td>\n",
+       "      <td>2026.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>8, 33</td>\n",
+       "      <td>8, 47</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>Skipjack Wind 1 &amp; 2</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>Orsted</td>\n",
+       "      <td>Contracted</td>\n",
+       "      <td>Rehoboth Beach,Dagsboro</td>\n",
+       "      <td>Sussex Couty</td>\n",
+       "      <td>Sparrows Point,Federalsburg</td>\n",
+       "      <td>966</td>\n",
+       "      <td>2026.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>41, 11</td>\n",
+       "      <td>46, 16</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>Marwin</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>US Wind</td>\n",
+       "      <td>Contracted</td>\n",
+       "      <td>Rehoboth Beach,Dagsboro</td>\n",
+       "      <td>Sussex Couty</td>\n",
+       "      <td>Sparrows Point,Ocean City</td>\n",
+       "      <td>248</td>\n",
+       "      <td>2026.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>41, 11</td>\n",
+       "      <td>46, 32</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>Atlantic Shores</td>\n",
+       "      <td>NJ</td>\n",
+       "      <td>Shell,EDF</td>\n",
+       "      <td>Contracted</td>\n",
+       "      <td>Atlantic City,Sea Girt</td>\n",
+       "      <td>Atlantic County, Monmouth County</td>\n",
+       "      <td>Paulsboro,Lower Alloways Creek</td>\n",
+       "      <td>1510</td>\n",
+       "      <td>2028.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2, 43</td>\n",
+       "      <td>35, 24</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>Beacon Wind</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>Equinor,BP</td>\n",
+       "      <td>Contracted</td>\n",
+       "      <td>Queens</td>\n",
+       "      <td>Queens County</td>\n",
+       "      <td>Brooklyn,Albany</td>\n",
+       "      <td>1230</td>\n",
+       "      <td>2028.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>40</td>\n",
+       "      <td>8, 1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                       Name Recipient State         Developer  \\\n",
+       "project_id                                                                      \n",
+       "1                         Commonwealth Wind              MA          Avangrid   \n",
+       "2                       Kitty Hawk Offshore             TBD          Avangrid   \n",
+       "3                             Vineyard Wind              MA      Avangrid,CIP   \n",
+       "4                      South Fork Wind Farm              NY            Orsted   \n",
+       "5                           Revolution Wind           RI,CT            Orsted   \n",
+       "6                         Ocean Wind  1 & 2              NJ            Orsted   \n",
+       "7                            Mayflower Wind              MA  Shell,EDPR,Engie   \n",
+       "8                              Sunrise Wind              NY            Orsted   \n",
+       "9                            Park City Wind              CT          Avangrid   \n",
+       "10          Coastal Virginia Offshore Wind               VA          Dominion   \n",
+       "11                            Momentum Wind              MD           US Wind   \n",
+       "12                        Empire Wind 1 & 2              NY        Equinor,BP   \n",
+       "13                      Skipjack Wind 1 & 2              MD            Orsted   \n",
+       "14                                   Marwin              MD           US Wind   \n",
+       "15                          Atlantic Shores              NJ         Shell,EDF   \n",
+       "16                              Beacon Wind              NY        Equinor,BP   \n",
+       "\n",
+       "                                       Status  \\\n",
+       "project_id                                      \n",
+       "1                                  Contracted   \n",
+       "2           Permitting underway - no contract   \n",
+       "3                          Under construction   \n",
+       "4                          Under construction   \n",
+       "5                                  Contracted   \n",
+       "6                                  Contracted   \n",
+       "7                                  Contracted   \n",
+       "8                                  Contracted   \n",
+       "9                                  Contracted   \n",
+       "10                                 Contracted   \n",
+       "11                                 Contracted   \n",
+       "12                                 Contracted   \n",
+       "13                                 Contracted   \n",
+       "14                                 Contracted   \n",
+       "15                                 Contracted   \n",
+       "16                                 Contracted   \n",
+       "\n",
+       "                          Proposed cable landing  \\\n",
+       "project_id                                         \n",
+       "1                                     Barnstable   \n",
+       "2                     Virginia Beach,Dare County   \n",
+       "3                                     Barnstable   \n",
+       "4                                   East Hampton   \n",
+       "5                                North Kingstown   \n",
+       "6           Seaside Park,Ocean City,Forked River   \n",
+       "7                              Somerset,Falmouth   \n",
+       "8                                     Brookhaven   \n",
+       "9                                     Barnstable   \n",
+       "10                                Virginia Beach   \n",
+       "11                       Rehoboth Beach,Dagsboro   \n",
+       "12                            Brooklyn,Oceanside   \n",
+       "13                       Rehoboth Beach,Dagsboro   \n",
+       "14                       Rehoboth Beach,Dagsboro   \n",
+       "15                        Atlantic City,Sea Girt   \n",
+       "16                                        Queens   \n",
+       "\n",
+       "                      County of Cable Landing  \\\n",
+       "project_id                                      \n",
+       "1                           Barnstable County   \n",
+       "2                 Dare County, Virginia Beach   \n",
+       "3                           Barnstable County   \n",
+       "4                              Suffolk County   \n",
+       "5                           Washington County   \n",
+       "6                      Ocean County, Cape May   \n",
+       "7           Bristol County, Barnstable County   \n",
+       "8                              Suffolk County   \n",
+       "9                           Barnstable County   \n",
+       "10                      Virginia Beach County   \n",
+       "11                               Sussex Couty   \n",
+       "12                Kings County, Nassau County   \n",
+       "13                               Sussex Couty   \n",
+       "14                               Sussex Couty   \n",
+       "15           Atlantic County, Monmouth County   \n",
+       "16                              Queens County   \n",
+       "\n",
+       "                                          Port Locations  Size (megawatts)  \\\n",
+       "project_id                                                                   \n",
+       "1                                         Somerset,Salem               800   \n",
+       "2                                                    NaN              2500   \n",
+       "3                                      New Bedford,Salem               800   \n",
+       "4                                     New London,Montauk               132   \n",
+       "5                  North Kingstown,Providence,New London               700   \n",
+       "6           Paulsboro,Lower Alloways Creek,Atlantic City              2248   \n",
+       "7                                            New Bedford              1204   \n",
+       "8                     New London,Port Jefferson,Coeymans               924   \n",
+       "9                                       Bridgeport,Salem               804   \n",
+       "10                                         Hampton Roads              2600   \n",
+       "11                             Sparrows Point,Ocean City               809   \n",
+       "12                                Brooklyn,Staten Island              2076   \n",
+       "13                           Sparrows Point,Federalsburg               966   \n",
+       "14                             Sparrows Point,Ocean City               248   \n",
+       "15                        Paulsboro,Lower Alloways Creek              1510   \n",
+       "16                                       Brooklyn,Albany              1230   \n",
+       "\n",
+       "            Online date  Notes Cable Location IDs Port Location IDs  \n",
+       "project_id                                                           \n",
+       "1                   NaN    NaN                  3            45, 42  \n",
+       "2                   NaN    NaN             49, 12               NaN  \n",
+       "3                2023.0    NaN                  3            28, 42  \n",
+       "4                2023.0    NaN                 13            29, 25  \n",
+       "5                2023.0    NaN                 30        30, 39, 29  \n",
+       "6                2024.0    NaN         44, 31, 17         35, 24, 2  \n",
+       "7                2025.0    NaN             45, 15                28  \n",
+       "8                2025.0    NaN                  6         29, 37, 9  \n",
+       "9                2025.0    NaN                  3             5, 42  \n",
+       "10               2026.0    NaN                 49                20  \n",
+       "11               2026.0    NaN             41, 11            46, 32  \n",
+       "12               2026.0    NaN              8, 33             8, 47  \n",
+       "13               2026.0    NaN             41, 11            46, 16  \n",
+       "14               2026.0    NaN             41, 11            46, 32  \n",
+       "15               2028.0    NaN              2, 43            35, 24  \n",
+       "16               2028.0    NaN                 40              8, 1  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "proj = pd.read_csv(path_projects, index_col='project_id')\n",
+    "proj"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c72309b5-a16f-4f13-aaf4-fcea35220002",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Int64Index: 16 entries, 1 to 16\n",
+      "Data columns (total 12 columns):\n",
+      " #   Column                   Non-Null Count  Dtype  \n",
+      "---  ------                   --------------  -----  \n",
+      " 0   Name                     16 non-null     object \n",
+      " 1   Recipient State          16 non-null     object \n",
+      " 2   Developer                16 non-null     object \n",
+      " 3   Status                   16 non-null     object \n",
+      " 4   Proposed cable landing   16 non-null     object \n",
+      " 5   County of Cable Landing  16 non-null     object \n",
+      " 6   Port Locations           15 non-null     object \n",
+      " 7   Size (megawatts)         16 non-null     int64  \n",
+      " 8   Online date              14 non-null     float64\n",
+      " 9   Notes                    0 non-null      float64\n",
+      " 10  Cable Location IDs       16 non-null     object \n",
+      " 11  Port Location IDs        15 non-null     object \n",
+      "dtypes: float64(2), int64(1), object(9)\n",
+      "memory usage: 1.6+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "proj.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c2aac459-6be1-4446-9dc5-00fd238f7ef2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>City</th>\n",
+       "      <th>State</th>\n",
+       "      <th>County</th>\n",
+       "      <th>County FIPS</th>\n",
+       "      <th>Why of interest?</th>\n",
+       "      <th>Priority</th>\n",
+       "      <th>Cable landing(s)</th>\n",
+       "      <th>Assembly/manufacturing</th>\n",
+       "      <th>Notes</th>\n",
+       "      <th>Cable project IDs</th>\n",
+       "      <th>assembly/manufac project IDs</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>location_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Albany</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>Albany County</td>\n",
+       "      <td>36001.0</td>\n",
+       "      <td>Contracted project</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Beacon Wind</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>16</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Atlantic City</td>\n",
+       "      <td>NJ</td>\n",
+       "      <td>Atlantic County</td>\n",
+       "      <td>34001.0</td>\n",
+       "      <td>Contracted project</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Atlantic Shores</td>\n",
+       "      <td>Ocean Wind  1 &amp; 2</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>15</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Barnstable</td>\n",
+       "      <td>MA</td>\n",
+       "      <td>Barnstable County</td>\n",
+       "      <td>25001.0</td>\n",
+       "      <td>Contracted project</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Vineyard Wind,Commonwealth Wind,Park City Wind</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3, 1, 9</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Beaumont</td>\n",
+       "      <td>TX</td>\n",
+       "      <td>Jefferson County</td>\n",
+       "      <td>48245.0</td>\n",
+       "      <td>Proposed lease area</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Bridgeport</td>\n",
+       "      <td>CT</td>\n",
+       "      <td>Fairfield County</td>\n",
+       "      <td>9001.0</td>\n",
+       "      <td>Contracted project</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Park City Wind</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>9</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                      City State             County  County FIPS  \\\n",
+       "location_id                                                        \n",
+       "1                   Albany    NY      Albany County      36001.0   \n",
+       "2            Atlantic City    NJ    Atlantic County      34001.0   \n",
+       "3               Barnstable    MA  Barnstable County      25001.0   \n",
+       "4                 Beaumont    TX   Jefferson County      48245.0   \n",
+       "5               Bridgeport    CT   Fairfield County       9001.0   \n",
+       "\n",
+       "                Why of interest?  Priority  \\\n",
+       "location_id                                  \n",
+       "1             Contracted project       NaN   \n",
+       "2             Contracted project       NaN   \n",
+       "3             Contracted project       NaN   \n",
+       "4            Proposed lease area       NaN   \n",
+       "5             Contracted project       NaN   \n",
+       "\n",
+       "                                           Cable landing(s)  \\\n",
+       "location_id                                                   \n",
+       "1                                                       NaN   \n",
+       "2                                           Atlantic Shores   \n",
+       "3            Vineyard Wind,Commonwealth Wind,Park City Wind   \n",
+       "4                                                       NaN   \n",
+       "5                                                       NaN   \n",
+       "\n",
+       "            Assembly/manufacturing  Notes Cable project IDs  \\\n",
+       "location_id                                                   \n",
+       "1                      Beacon Wind    NaN               NaN   \n",
+       "2                Ocean Wind  1 & 2    NaN                15   \n",
+       "3                              NaN    NaN           3, 1, 9   \n",
+       "4                              NaN    NaN               NaN   \n",
+       "5                   Park City Wind    NaN               NaN   \n",
+       "\n",
+       "            assembly/manufac project IDs  \n",
+       "location_id                               \n",
+       "1                                     16  \n",
+       "2                                      6  \n",
+       "3                                    NaN  \n",
+       "4                                    NaN  \n",
+       "5                                      9  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "locs = pd.read_csv(path_locations, index_col='location_id')\n",
+    "locs.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "76f8e4f1-445d-4273-b076-2b7bb69a7afa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Int64Index: 50 entries, 1 to 50\n",
+      "Data columns (total 11 columns):\n",
+      " #   Column                        Non-Null Count  Dtype  \n",
+      "---  ------                        --------------  -----  \n",
+      " 0   City                          50 non-null     object \n",
+      " 1   State                         50 non-null     object \n",
+      " 2   County                        49 non-null     object \n",
+      " 3   County FIPS                   49 non-null     float64\n",
+      " 4   Why of interest?              50 non-null     object \n",
+      " 5   Priority                      0 non-null      float64\n",
+      " 6   Cable landing(s)              18 non-null     object \n",
+      " 7   Assembly/manufacturing        20 non-null     object \n",
+      " 8   Notes                         0 non-null      float64\n",
+      " 9   Cable project IDs             18 non-null     object \n",
+      " 10  assembly/manufac project IDs  20 non-null     object \n",
+      "dtypes: float64(3), object(8)\n",
+      "memory usage: 4.7+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "locs.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fa99b99-299f-4fed-985b-bcb3b8008802",
+   "metadata": {},
+   "source": [
+    "## Cleaning\n",
+    "### Accuracy\n",
+    "This is another consultant's responsibility.\n",
+    "### Atomicity\n",
+    "Projects has several multi-valued columns:\n",
+    "* Recipient State\n",
+    "* Developer\n",
+    "\n",
+    "And several multi-valued columns with corresponding multivalued IDs:\n",
+    "* Proposed cable landing\n",
+    "* County of cable landing\n",
+    "* Port Locations\n",
+    "\n",
+    "I believe all of those except `Developer` have foreign key relationships to the locations table.\n",
+    "\n",
+    "Locations also has multi-valued columns with corresponding multivalued IDs:\n",
+    "* Assembly/manufacturing\n",
+    "* Cable landing(s)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f2b46b7-f55e-4dc4-b44a-055da3f45f40",
+   "metadata": {},
+   "source": [
+    "### Completeness\n",
+    "* Hampton Roads, VA is a MSA consisting of 10-19 counties (depending on definition). I'll ask for more clarification, else split it amongst all of those."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ef370d6a-a2bb-4941-bf7c-d1fd528e54f7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Name                        0\n",
+       "Recipient State             0\n",
+       "Developer                   0\n",
+       "Status                      0\n",
+       "Proposed cable landing      0\n",
+       "County of Cable Landing     0\n",
+       "Port Locations              1\n",
+       "Size (megawatts)            0\n",
+       "Online date                 2\n",
+       "Notes                      16\n",
+       "Cable Location IDs          0\n",
+       "Port Location IDs           1\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "proj.isna().sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d87fb1a9-e001-4284-8341-9b403ddfe393",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "City                             0\n",
+       "State                            0\n",
+       "County                           1\n",
+       "County FIPS                      1\n",
+       "Why of interest?                 0\n",
+       "Priority                        50\n",
+       "Cable landing(s)                32\n",
+       "Assembly/manufacturing          30\n",
+       "Notes                           50\n",
+       "Cable project IDs               32\n",
+       "assembly/manufac project IDs    30\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "locs.isna().sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "7150af63-9653-439b-8794-0ddb8aece67a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Why of interest?         Cable landing(s)\n",
+       "Contracted project       False               17\n",
+       "                         True                16\n",
+       "Proposed lease area      True                13\n",
+       "Lease area in proximity  True                 3\n",
+       "                         False                1\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.concat([locs['Why of interest?'], locs['Cable landing(s)'].isna()], axis=1).value_counts(dropna=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eab608da-c1b5-4af6-843f-cfe854fe5c55",
+   "metadata": {},
+   "source": [
+    "### Uniformity\n",
+    "* all states are represented as abbreviations\n",
+    "#### Null Representation\n",
+    "* the only non-standard Null value is \"TBD\" in `Recipient State`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "b90670f9-b11d-4f26-a659-7dbf89533b50",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Name                       False\n",
+       "Recipient State            False\n",
+       "Developer                  False\n",
+       "Status                     False\n",
+       "Proposed cable landing     False\n",
+       "County of Cable Landing    False\n",
+       "Port Locations             False\n",
+       "Size (megawatts)           False\n",
+       "Online date                False\n",
+       "Notes                      False\n",
+       "Cable Location IDs         False\n",
+       "Port Location IDs          False\n",
+       "dtype: bool"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "proj.eq('').any()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "1622a629-b88c-4999-b425-f4894639613f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "City                            False\n",
+       "State                           False\n",
+       "County                          False\n",
+       "County FIPS                     False\n",
+       "Why of interest?                False\n",
+       "Priority                        False\n",
+       "Cable landing(s)                False\n",
+       "Assembly/manufacturing          False\n",
+       "Notes                           False\n",
+       "Cable project IDs               False\n",
+       "assembly/manufac project IDs    False\n",
+       "dtype: bool"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "locs.eq('').any()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "82b3945e-d1e6-4bcb-a48a-874d40be27a4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "project_id\n",
+       "1     MA\n",
+       "2    TBD\n",
+       "3     MA\n",
+       "Name: Recipient State, dtype: object"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "proj['Recipient State'].head(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35a04099-128c-4a84-9042-66e7b8f9e8ab",
+   "metadata": {},
+   "source": [
+    "### Validity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae6f1693-0da7-48eb-9174-4bf4951992ba",
+   "metadata": {},
+   "source": [
+    "#### Range"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "93774d3b-9062-488c-9e6c-d73bacb7c28c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot: >"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAhYAAAGdCAYAAABO2DpVAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy89olMNAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAb+ElEQVR4nO3de5DVdf348dcCy5FNDogrN10MtXAU0bzRlholiOiYVn+YOGWOY5Nhk4OaQ02y9M3RqRmnpsycLvpPqNl4mXFS21QkC01IU9RhxCjMQARiF1g9Ht337w9/rG6wwFnf58BZHo+ZM3HO+eznvM/Lz559ds6ePQ0ppRQAABkM2tMLAAAGDmEBAGQjLACAbIQFAJCNsAAAshEWAEA2wgIAyEZYAADZDKn1DXZ3d8d//vOfGD58eDQ0NNT65gGAfkgpxebNm2P8+PExaFDfz0vUPCz+85//REtLS61vFgDI4JVXXolDDjmkz+trHhbDhw+PiHcXViwWa33z+4RyuRx/+MMf4owzzojGxsY9vZwBz7xrx6xrx6xrqx7m3dnZGS0tLT0/x/tS87DY9vJHsVgUFlVSLpejqakpisXiXnuADiTmXTtmXTtmXVv1NO9d/RqDX94EALIRFgBANsICAMhGWAAA2QgLACAbYQEAZCMsAIBshAUAkI2wAACyERYAQDYVhUVbW1s0NDT0Oh155JHVWhsAUGcq/qyQo48+Ov74xz++t4MhNf+4EQBgL1VxFQwZMiTGjh1bjbUAAHWu4rB46aWXYvz48bHffvtFa2trXH/99TFhwoQ+ty+VSlEqlXrOd3Z2RsS7n+RWLpf7sWR2Zdtczbc2zLt2zLp2zLq26mHeu7u2hpRS2t2dPvDAA7Fly5aYNGlSrFmzJhYsWBCvvvpqLF++vM/PZ29ra4sFCxZsd/nChQujqalpd28aANiDurq6Yvbs2dHR0RHFYrHP7SoKi/+1adOmOPTQQ+PGG2+MSy65ZIfb7OgZi5aWlli/fv1OF0b/lcvlaG9vjxkzZkRjY2P2/U9ueyj7PqttedvMqu272vPmPWZdO2ZdW/Uw787Ozmhubt5lWHyg37wcOXJkfPSjH42VK1f2uU2hUIhCobDd5Y2NjXvt8AaKas249E5D9n1WWy2ONcd07Zh17Zh1be3N897ddX2gv2OxZcuWePnll2PcuHEfZDcAwABRUVhcddVV8dhjj8U///nP+Mtf/hKf+9znYvDgwXHBBRdUa30AQB2p6KWQf//733HBBRfEhg0b4qCDDopTTjklnnjiiTjooIOqtT4AoI5UFBZ33HFHtdYBAAwAPisEAMhGWAAA2QgLACAbYQEAZCMsAIBshAUAkI2wAACyERYAQDbCAgDIRlgAANkICwAgG2EBAGQjLACAbIQFAJCNsAAAshEWAEA2wgIAyEZYAADZCAsAIBthAQBkIywAgGyEBQCQjbAAALIRFgBANsICAMhGWAAA2QgLACAbYQEAZCMsAIBshAUAkI2wAACyERYAQDbCAgDIRlgAANkICwAgG2EBAGQjLACAbIQFAJCNsAAAshEWAEA2wgIAyEZYAADZCAsAIBthAQBkIywAgGyEBQCQjbAAALIRFgBANsICAMhGWAAA2QgLACAbYQEAZCMsAIBshAUAkI2wAACyERYAQDbCAgDIRlgAANkICwAgG2EBAGTzgcLihhtuiIaGhrjiiisyLQcAqGf9DounnnoqbrnllpgyZUrO9QAAdaxfYbFly5a48MIL4xe/+EUccMABudcEANSpIf35ojlz5sTZZ58d06dPj+9///s73bZUKkWpVOo539nZGRER5XI5yuVyf26eXdg212rNtzA4VWW/1VTNY63a8+Y9Zl07Zl1b9TDv3V1bQ0qpop8Sd9xxR1x33XXx1FNPxX777RfTpk2L4447Ln70ox/tcPu2trZYsGDBdpcvXLgwmpqaKrlpAGAP6erqitmzZ0dHR0cUi8U+t6soLF555ZU48cQTo729ved3K3YVFjt6xqKlpSXWr1+/04XRf+VyOdrb22PGjBnR2NiYff+T2x7Kvs9qW942s2r7rva8eY9Z145Z11Y9zLuzszOam5t3GRYVvRSybNmyWLduXRx//PE9l73zzjuxePHi+OlPfxqlUikGDx7c62sKhUIUCoXt9tXY2LjXDm+gqNaMS+80ZN9ntdXiWHNM145Z145Z19bePO/dXVdFYXH66afHc8891+uyiy++OI488si45pprtosKAGDfUlFYDB8+PCZPntzrsg996ENx4IEHbnc5ALDv8Zc3AYBs+vV20/dbtGhRhmUAAAOBZywAgGyEBQCQjbAAALIRFgBANsICAMhGWAAA2QgLACAbYQEAZCMsAIBshAUAkI2wAACyERYAQDbCAgDIRlgAANkICwAgG2EBAGQjLACAbIQFAJCNsAAAshEWAEA2wgIAyEZYAADZCAsAIBthAQBkIywAgGyEBQCQjbAAALIRFgBANsICAMhGWAAA2QgLACAbYQEAZCMsAIBshAUAkI2wAACyERYAQDbCAgDIRlgAANkICwAgG2EBAGQjLACAbIQFAJCNsAAAshEWAEA2wgIAyEZYAADZCAsAIBthAQBkIywAgGyEBQCQjbAAALIRFgBANsICAMhGWAAA2QgLACAbYQEAZCMsAIBshAUAkI2wAACyqSgsbr755pgyZUoUi8UoFovR2toaDzzwQLXWBgDUmYrC4pBDDokbbrghli1bFkuXLo3PfOYzce6558bzzz9frfUBAHVkSCUbn3POOb3OX3fddXHzzTfHE088EUcffXTWhQEA9aeisHi/d955J+66667YunVrtLa29rldqVSKUqnUc76zszMiIsrlcpTL5f7ePDuxba7Vmm9hcKrKfqupmsdatefNe8y6dsy6tuph3ru7toaUUkU/JZ577rlobW2NN998M/bff/9YuHBhnHXWWX1u39bWFgsWLNju8oULF0ZTU1MlNw0A7CFdXV0xe/bs6OjoiGKx2Od2FYfFW2+9FatXr46Ojo743e9+F7/85S/jsccei6OOOmqH2+/oGYuWlpZYv379ThdG/5XL5Whvb48ZM2ZEY2Nj9v1Pbnso+z6rbXnbzKrtu9rz5j1mXTtmXVv1MO/Ozs5obm7eZVhU/FLI0KFD44gjjoiIiBNOOCGeeuqp+PGPfxy33HLLDrcvFApRKBS2u7yxsXGvHd5AUa0Zl95pyL7PaqvFseaYrh2zrh2zrq29ed67u64P/Hcsuru7ez0jAQDsuyp6xmLevHkxa9asmDBhQmzevDkWLlwYixYtioceqr+nxgGA/CoKi3Xr1sWXv/zlWLNmTYwYMSKmTJkSDz30UMyYMaNa6wMA6khFYfGrX/2qWusAAAYAnxUCAGQjLACAbIQFAJCNsAAAshEWAEA2wgIAyEZYAADZCAsAIBthAQBkIywAgGyEBQCQjbAAALIRFgBANsICAMhGWAAA2QgLACAbYQEAZCMsAIBshAUAkI2wAACyERYAQDbCAgDIRlgAANkICwAgG2EBAGQjLACAbIQFAJCNsAAAshEWAEA2wgIAyEZYAADZCAsAIBthAQBkIywAgGyEBQCQjbAAALIRFgBANsICAMhGWAAA2QgLACAbYQEAZCMsAIBshAUAkI2wAACyERYAQDbCAgDIRlgAANkICwAgG2EBAGQjLACAbIQFAJCNsAAAshEWAEA2wgIAyEZYAADZCAsAIBthAQBkIywAgGyEBQCQTUVhcf3118dJJ50Uw4cPj9GjR8d5550XK1asqNbaAIA6U1FYPPbYYzFnzpx44oknor29PcrlcpxxxhmxdevWaq0PAKgjQyrZ+MEHH+x1/rbbbovRo0fHsmXL4rTTTsu6MACg/lQUFv+ro6MjIiJGjRrV5zalUilKpVLP+c7OzoiIKJfLUS6XP8jN04dtc63WfAuDU1X2W03VPNaqPW/eY9a1Y9a1VQ/z3t21NaSU+vVToru7Oz772c/Gpk2b4vHHH+9zu7a2tliwYMF2ly9cuDCampr6c9MAQI11dXXF7Nmzo6OjI4rFYp/b9TssLrvssnjggQfi8ccfj0MOOaTP7Xb0jEVLS0usX79+pwvrj8ltD2XdXy0sb5uZfZ/lcjna29tjxowZ0djYmH3/9TjnaioMSvF/J3bHd5cOilJ3w55ezh5XjWN6m2of27zHrN9Vq8e7nI8j1foe7OzsjObm5l2GRb9eCrn88svj/vvvj8WLF+80KiIiCoVCFAqF7S5vbGzMfrCW3qm/B/VqfsNWY8YR9TnnWih1N5hNVPeYfv9t7Ms/7GppX591rb+nczyOVOu/1+7ut6KwSCnFN77xjbjnnnti0aJFMXHixH4tDgAYmCoKizlz5sTChQvjvvvui+HDh8fatWsjImLEiBExbNiwqiwQAKgfFf0di5tvvjk6Ojpi2rRpMW7cuJ7TnXfeWa31AQB1pOKXQgAA+uKzQgCAbIQFAJCNsAAAshEWAEA2wgIAyEZYAADZCAsAIBthAQBkIywAgGyEBQCQjbAAALIRFgBANsICAMhGWAAA2QgLACAbYQEAZCMsAIBshAUAkI2wAACyERYAQDbCAgDIRlgAANkICwAgG2EBAGQjLACAbIQFAJCNsAAAshEWAEA2wgIAyEZYAADZCAsAIBthAQBkIywAgGyEBQCQjbAAALIRFgBANsICAMhGWAAA2QgLACAbYQEAZCMsAIBshAUAkI2wAACyERYAQDbCAgDIRlgAANkICwAgG2EBAGQjLACAbIQFAJCNsAAAshEWAEA2wgIAyEZYAADZCAsAIBthAQBkIywAgGyEBQCQjbAAALIRFgBANhWHxeLFi+Occ86J8ePHR0NDQ9x7771VWBYAUI8qDoutW7fGscceGzfddFM11gMA1LEhlX7BrFmzYtasWdVYCwBQ5yoOi0qVSqUolUo95zs7OyMiolwuR7lcznpbhcEp6/5qIfcM3r/Pauw7oj7nXE2FQanX/+7rqnXcvX/f1bwN3mXW76rV413Ox5Fq/Tfb3f02pJT6fS8aGhrinnvuifPOO6/Pbdra2mLBggXbXb5w4cJoamrq700DADXU1dUVs2fPjo6OjigWi31uV/Ww2NEzFi0tLbF+/fqdLqw/Jrc9lHV/tbC8bWb2fZbL5Whvb48ZM2ZEY2Nj9v3X45yrqTAoxf+d2B3fXTooSt0Ne3o5A1q1Zl2N78Nqq/b3oeO6tnLOu1rHc2dnZzQ3N+8yLKr+UkihUIhCobDd5Y2Njdl/6JXeqb+Dvxo/+N+/72rsvx7nXAul7gazqZHcs67m92G11OpYc1zXVo55V+t43t39+jsWAEA2FT9jsWXLlli5cmXP+VWrVsUzzzwTo0aNigkTJmRdHABQXyoOi6VLl8anP/3pnvNz586NiIiLLroobrvttmwLAwDqT8VhMW3atPgAv+8JAAxgfscCAMhGWAAA2QgLACAbYQEAZCMsAIBshAUAkI2wAACyERYAQDbCAgDIRlgAANkICwAgG2EBAGQjLACAbIQFAJCNsAAAshEWAEA2wgIAyEZYAADZCAsAIBthAQBkIywAgGyEBQCQjbAAALIRFgBANsICAMhGWAAA2QgLACAbYQEAZCMsAIBshAUAkI2wAACyERYAQDbCAgDIRlgAANkICwAgG2EBAGQjLACAbIQFAJCNsAAAshEWAEA2wgIAyEZYAADZCAsAIBthAQBkIywAgGyEBQCQjbAAALIRFgBANsICAMhGWAAA2QgLACAbYQEAZCMsAIBshAUAkI2wAACyERYAQDbCAgDIRlgAANkICwAgm36FxU033RQf/vCHY7/99oupU6fGX//619zrAgDqUMVhceedd8bcuXNj/vz58be//S2OPfbYmDlzZqxbt64a6wMA6kjFYXHjjTfGpZdeGhdffHEcddRR8fOf/zyampri17/+dTXWBwDUkSGVbPzWW2/FsmXLYt68eT2XDRo0KKZPnx5LlizZ4deUSqUolUo95zs6OiIiYuPGjVEul/uz5j4NeXtr1v3VwoYNG7Lvs1wuR1dXV2zYsCEaGxuz778e51xNQ7pTdHV1x5DyoHinu2FPL2dAq9asq/F9WG3V/j50XNdWznlX63jevHlzRESklHa+YarAq6++miIi/eUvf+l1+dVXX51OPvnkHX7N/PnzU0Q4OTk5OTk5DYDTK6+8stNWqOgZi/6YN29ezJ07t+d8d3d3bNy4MQ488MBoaFDB1dDZ2RktLS3xyiuvRLFY3NPLGfDMu3bMunbMurbqYd4ppdi8eXOMHz9+p9tVFBbNzc0xePDgeO2113pd/tprr8XYsWN3+DWFQiEKhUKvy0aOHFnJzdJPxWJxrz1AByLzrh2zrh2zrq29fd4jRozY5TYV/fLm0KFD44QTToiHH36457Lu7u54+OGHo7W1tfIVAgADSsUvhcydOzcuuuiiOPHEE+Pkk0+OH/3oR7F169a4+OKLq7E+AKCOVBwW559/frz++utx7bXXxtq1a+O4446LBx98MMaMGVON9dEPhUIh5s+fv91LUFSHedeOWdeOWdfWQJp3Q9rl+0YAAHaPzwoBALIRFgBANsICAMhGWAAA2QiLOtHW1hYNDQ29TkceeWTP9W+++WbMmTMnDjzwwNh///3jC1/4wnZ/yGz16tVx9tlnR1NTU4wePTquvvrqePvtt2t9V/ZKixcvjnPOOSfGjx8fDQ0Nce+99/a6PqUU1157bYwbNy6GDRsW06dPj5deeqnXNhs3bowLL7wwisVijBw5Mi655JLYsmVLr22effbZOPXUU2O//faLlpaW+MEPflDtu7bX2dWsv/KVr2x3rJ955pm9tjHr3XP99dfHSSedFMOHD4/Ro0fHeeedFytWrOi1Ta7HjkWLFsXxxx8fhUIhjjjiiLjtttuqfff2Krsz62nTpm13bH/ta1/rtc2AmHUlnxXCnjN//vx09NFHpzVr1vScXn/99Z7rv/a1r6WWlpb08MMPp6VLl6aPf/zj6ROf+ETP9W+//XaaPHlymj59enr66afT73//+9Tc3JzmzZu3J+7OXuf3v/99+s53vpPuvvvuFBHpnnvu6XX9DTfckEaMGJHuvffe9Pe//z199rOfTRMnTkxvvPFGzzZnnnlmOvbYY9MTTzyR/vSnP6UjjjgiXXDBBT3Xd3R0pDFjxqQLL7wwLV++PN1+++1p2LBh6ZZbbqnV3dwr7GrWF110UTrzzDN7HesbN27stY1Z756ZM2emW2+9NS1fvjw988wz6ayzzkoTJkxIW7Zs6dkmx2PHP/7xj9TU1JTmzp2bXnjhhfSTn/wkDR48OD344IM1vb970u7M+lOf+lS69NJLex3bHR0dPdcPlFkLizoxf/78dOyxx+7wuk2bNqXGxsZ011139Vz24osvpohIS5YsSSm9+2A+aNCgtHbt2p5tbr755lQsFlOpVKrq2uvN//6w6+7uTmPHjk0//OEPey7btGlTKhQK6fbbb08ppfTCCy+kiEhPPfVUzzYPPPBAamhoSK+++mpKKaWf/exn6YADDug172uuuSZNmjSpyvdo79VXWJx77rl9fo1Z99+6detSRKTHHnsspZTvseNb3/pWOvroo3vd1vnnn59mzpxZ7bu01/rfWaf0blh885vf7PNrBsqsvRRSR1566aUYP358HHbYYXHhhRfG6tWrIyJi2bJlUS6XY/r06T3bHnnkkTFhwoSej7NfsmRJHHPMMb3+kNnMmTOjs7Mznn/++drekTqzatWqWLt2ba/5jhgxIqZOndprviNHjowTTzyxZ5vp06fHoEGD4sknn+zZ5rTTTouhQ4f2bDNz5sxYsWJF/Pe//63RvakPixYtitGjR8ekSZPisssu6/Ux0Gbdfx0dHRERMWrUqIjI99ixZMmSXvvYts22feyL/nfW2/zmN7+J5ubmmDx5csybNy+6urp6rhsos676p5uSx9SpU+O2226LSZMmxZo1a2LBggVx6qmnxvLly2Pt2rUxdOjQ7T7cbcyYMbF27dqIiFi7du12fx112/lt27Bj2+azo/m9f76jR4/udf2QIUNi1KhRvbaZOHHidvvYdt0BBxxQlfXXmzPPPDM+//nPx8SJE+Pll1+Ob3/72zFr1qxYsmRJDB482Kz7qbu7O6644or45Cc/GZMnT46IyPbY0dc2nZ2d8cYbb8SwYcOqcZf2WjuadUTE7Nmz49BDD43x48fHs88+G9dcc02sWLEi7r777ogYOLMWFnVi1qxZPf+eMmVKTJ06NQ499ND47W9/u1ccSJDLF7/4xZ5/H3PMMTFlypQ4/PDDY9GiRXH66afvwZXVtzlz5sTy5cvj8ccf39NLGfD6mvVXv/rVnn8fc8wxMW7cuDj99NPj5ZdfjsMPP7zWy6waL4XUqZEjR8ZHP/rRWLlyZYwdOzbeeuut2LRpU69t3v9x9mPHjt3hx91vu46+bZvPjub3/vmuW7eu1/Vvv/12bNy40X+DD+iwww6L5ubmWLlyZUSYdX9cfvnlcf/998ejjz4ahxxySM/luR47+tqmWCzuc//Hp69Z78jUqVMjInod2wNh1sKiTm3ZsiVefvnlGDduXJxwwgnR2NjY6+PsV6xYEatXr+75OPvW1tZ47rnnej0gt7e3R7FYjKOOOqrm668nEydOjLFjx/aab2dnZzz55JO95rtp06ZYtmxZzzaPPPJIdHd39zx4tLa2xuLFi6NcLvds097eHpMmTdonn5rfXf/+979jw4YNMW7cuIgw60qklOLyyy+Pe+65Jx555JHtXh7K9djR2traax/bttm2j33Brma9I88880xERK9je0DMek//9ii758orr0yLFi1Kq1atSn/+85/T9OnTU3Nzc1q3bl1K6d23jE2YMCE98sgjaenSpam1tTW1trb2fP22tzGdccYZ6ZlnnkkPPvhgOuigg7zd9P/bvHlzevrpp9PTTz+dIiLdeOON6emnn07/+te/Ukrvvt105MiR6b777kvPPvtsOvfcc3f4dtOPfexj6cknn0yPP/54+shHPtLrLZCbNm1KY8aMSV/60pfS8uXL0x133JGampr2ubdA7mzWmzdvTldddVVasmRJWrVqVfrjH/+Yjj/++PSRj3wkvfnmmz37MOvdc9lll6URI0akRYsW9XqLY1dXV882OR47tr0F8uqrr04vvvhiuummm/a6t0BW265mvXLlyvS9730vLV26NK1atSrdd9996bDDDkunnXZazz4GyqyFRZ04//zz07hx49LQoUPTwQcfnM4///y0cuXKnuvfeOON9PWvfz0dcMABqampKX3uc59La9as6bWPf/7zn2nWrFlp2LBhqbm5OV155ZWpXC7X+q7slR599NEUEdudLrroopTSu285/e53v5vGjBmTCoVCOv3009OKFSt67WPDhg3pggsuSPvvv38qFovp4osvTps3b+61zd///vd0yimnpEKhkA4++OB0ww031Oou7jV2Nuuurq50xhlnpIMOOig1NjamQw89NF166aW93n6Xklnvrh3NOSLSrbfe2rNNrseORx99NB133HFp6NCh6bDDDut1G/uCXc169erV6bTTTkujRo1KhUIhHXHEEenqq6/u9XcsUhoYs/ax6QBANn7HAgDIRlgAANkICwAgG2EBAGQjLACAbIQFAJCNsAAAshEWAEA2wgIAyEZYAADZCAsAIBthAQBk8/8ArvZu+rFRVzkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "proj['Size (megawatts)'].hist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "e4fa5d81-b972-4fd0-8780-28e1b522bd72",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "project_id\n",
+       "4     132\n",
+       "14    248\n",
+       "5     700\n",
+       "Name: Size (megawatts), dtype: int64"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# are there really offshore projects < 300 MW? Google says yes 🤷🏼‍♂️\n",
+    "proj['Size (megawatts)'].nsmallest(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "3ccf0cb7-414f-4b74-bdfc-98d84ee896e8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count      14.000000\n",
+       "mean     2025.285714\n",
+       "std         1.637473\n",
+       "min      2023.000000\n",
+       "25%      2024.250000\n",
+       "50%      2025.500000\n",
+       "75%      2026.000000\n",
+       "max      2028.000000\n",
+       "Name: Online date, dtype: float64"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "proj['Online date'].describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a6de26b-634b-4b46-9a94-51b1dd384484",
+   "metadata": {},
+   "source": [
+    "#### Uniqueness\n",
+    "* (`city`, `state`) currently works as the primary key of locations. I added an autoincrementing integer ID `location_id` in Airtable to ensure this isn't a problem in the future.\n",
+    "* I think if there are multiple `why of interest?` in the future, they will be represented with array values like `cable landings` and `assembly/manufacturing` are currently.\n",
+    "* `Name` is the current primary key for projects, but name collisions are possible in the future. I added an autoincrementing integer ID `project_id` in Airtable to ensure this isn't a problem in the future."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "4c0f38c7-5d86-49da-8535-32a77b770618",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "locs['City'].is_unique"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "b6ebd662-b0ce-4515-9802-720bcce6756d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "locs.index.is_unique # location_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "624950c7-b08f-414c-90b4-d02b92dca915",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "locs[['City', 'State']].duplicated().any()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "990951dc-e1b3-4d01-853c-59769509b7be",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>City</th>\n",
+       "      <th>State</th>\n",
+       "      <th>County</th>\n",
+       "      <th>County FIPS</th>\n",
+       "      <th>Why of interest?</th>\n",
+       "      <th>Priority</th>\n",
+       "      <th>Cable landing(s)</th>\n",
+       "      <th>Assembly/manufacturing</th>\n",
+       "      <th>Notes</th>\n",
+       "      <th>Cable project IDs</th>\n",
+       "      <th>assembly/manufac project IDs</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>location_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>31</th>\n",
+       "      <td>Ocean City</td>\n",
+       "      <td>NJ</td>\n",
+       "      <td>Cape May</td>\n",
+       "      <td>34009.0</td>\n",
+       "      <td>Contracted project</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Ocean Wind  1 &amp; 2</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>6</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>32</th>\n",
+       "      <td>Ocean City</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>Worcester</td>\n",
+       "      <td>24047.0</td>\n",
+       "      <td>Contracted project</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Marwin,Momentum Wind</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>14, 11</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   City State     County  County FIPS    Why of interest?  \\\n",
+       "location_id                                                                 \n",
+       "31           Ocean City    NJ   Cape May      34009.0  Contracted project   \n",
+       "32           Ocean City    MD  Worcester      24047.0  Contracted project   \n",
+       "\n",
+       "             Priority   Cable landing(s) Assembly/manufacturing  Notes  \\\n",
+       "location_id                                                              \n",
+       "31                NaN  Ocean Wind  1 & 2                    NaN    NaN   \n",
+       "32                NaN                NaN   Marwin,Momentum Wind    NaN   \n",
+       "\n",
+       "            Cable project IDs assembly/manufac project IDs  \n",
+       "location_id                                                 \n",
+       "31                          6                          NaN  \n",
+       "32                        NaN                       14, 11  "
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "locs.loc[locs.duplicated(subset=['City'], keep=False),:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "63ace153-1601-4276-b6fb-22f3eb73c59c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "proj['Name'].is_unique"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "a0d8ddcf-5b5a-428c-9e85-808cb45c8475",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "proj.index.is_unique # project_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6b42d71-380a-4899-a899-68bec815eb60",
+   "metadata": {},
+   "source": [
+    "#### Set Membership"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "5618b0c7-73e3-49ca-8fbb-fea02b66db51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def split_and_stack_multivalued_series(ser: pd.Series, name='state') -> pd.Series:\n",
+    "    return ser.str.split(',', expand=True).melt(value_vars=[0,1], value_name=name).dropna().loc[:,name].copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "cc4b8a45-116a-4abe-acdd-0297db6f3359",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "catalystcoop.pudl             0.6.0\n",
+      "\u001b[33mWARNING: You are using pip version 22.0.4; however, version 22.3.1 is available.\n",
+      "You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.\u001b[0m\u001b[33m\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "!pip list | grep pudl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "dbe59c14-ee1a-4b5b-bb7b-88527f577272",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/app/.local/lib/python3.9/site-packages/geopandas/_compat.py:111: UserWarning: The Shapely GEOS version (3.10.3-CAPI-1.16.1) is incompatible with the GEOS version PyGEOS was compiled with (3.10.1-CAPI-1.16.0). Conversions between both will be slow.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pudl.metadata.enums import US_STATES\n",
+    "states = set(US_STATES.keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "1301cfda-cf44-49fe-887e-05c9816ae649",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is for a later version of PUDL\n",
+    "# from pudl.metadata.dfs import POLITICAL_SUBDIVISIONS\n",
+    "# states = set(POLITICAL_SUBDIVISIONS.loc[POLITICAL_SUBDIVISIONS['subdivision_type'].eq('state'), 'subdivision_code'].to_list())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "dacbfbd1-2e9f-4c6d-8f4f-2cc6966ce5a3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "50"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(states)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "714a3038-bec6-4cfa-9eb9-e8e6143eca17",
+   "metadata": {},
+   "source": [
+    "##### Projects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "7fc4fb11-8fdc-43c0-90b5-2b376dbaf017",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert locs['State'].isin(states).all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "f7a9dfa8-b9dc-44ed-9959-81182dc8c4ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ignore the one null value for now\n",
+    "assert split_and_stack_multivalued_series(proj['Recipient State'].replace({'TBD': np.nan}).dropna()).isin(states).all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "c5fe055e-21d5-4393-bf25-2433f733a7a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Avangrid    4\n",
+       "BP          2\n",
+       "CIP         1\n",
+       "Dominion    1\n",
+       "EDF         1\n",
+       "EDPR        1\n",
+       "Equinor     2\n",
+       "Orsted      5\n",
+       "Shell       2\n",
+       "US Wind     2\n",
+       "Name: state, dtype: int64"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "split_and_stack_multivalued_series(proj['Developer']).value_counts(dropna=False).sort_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "acce9b7c-0489-43f6-9386-6c692d2eec1c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Contracted                           13\n",
+       "Under construction                    2\n",
+       "Permitting underway - no contract     1\n",
+       "Name: Status, dtype: int64"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "proj['Status'].value_counts(dropna=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76141c1a-2ff7-497c-8ea2-f85ec484ffa1",
+   "metadata": {},
+   "source": [
+    "##### Locations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "206788ae-a88d-4a60-a1a8-91fe5ede0318",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert locs['State'].isin(states).all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "517c0777-3ada-4b24-b1d7-a606576177f9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Contracted project         33\n",
+       "Proposed lease area        13\n",
+       "Lease area in proximity     4\n",
+       "Name: Why of interest?, dtype: int64"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "locs['Why of interest?'].value_counts(dropna=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ff4846f-a5bd-4ed0-9d0c-c7fb6c9d1a7c",
+   "metadata": {},
+   "source": [
+    "#### Type\n",
+    "* make sure FIPS is a string\n",
+    "* cast `Priority` and `Notes`, which are both entirely Null, to their intended type of string\n",
+    "\n",
+    "Projects:\n",
+    "* size should be a float just in case\n",
+    "* online date should be a nullable int\n",
+    "* again notes should be string"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "8e3698a1-da27-47bf-acda-39e70b2c6d0c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Int64Index: 50 entries, 1 to 50\n",
+      "Data columns (total 11 columns):\n",
+      " #   Column                        Non-Null Count  Dtype  \n",
+      "---  ------                        --------------  -----  \n",
+      " 0   City                          50 non-null     object \n",
+      " 1   State                         50 non-null     object \n",
+      " 2   County                        49 non-null     object \n",
+      " 3   County FIPS                   49 non-null     float64\n",
+      " 4   Why of interest?              50 non-null     object \n",
+      " 5   Priority                      0 non-null      float64\n",
+      " 6   Cable landing(s)              18 non-null     object \n",
+      " 7   Assembly/manufacturing        20 non-null     object \n",
+      " 8   Notes                         0 non-null      float64\n",
+      " 9   Cable project IDs             18 non-null     object \n",
+      " 10  assembly/manufac project IDs  20 non-null     object \n",
+      "dtypes: float64(3), object(8)\n",
+      "memory usage: 6.7+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "locs.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "67e8d7cf-43e9-4186-b6ca-e8b002d86047",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Int64Index: 16 entries, 1 to 16\n",
+      "Data columns (total 12 columns):\n",
+      " #   Column                   Non-Null Count  Dtype  \n",
+      "---  ------                   --------------  -----  \n",
+      " 0   Name                     16 non-null     object \n",
+      " 1   Recipient State          16 non-null     object \n",
+      " 2   Developer                16 non-null     object \n",
+      " 3   Status                   16 non-null     object \n",
+      " 4   Proposed cable landing   16 non-null     object \n",
+      " 5   County of Cable Landing  16 non-null     object \n",
+      " 6   Port Locations           15 non-null     object \n",
+      " 7   Size (megawatts)         16 non-null     int64  \n",
+      " 8   Online date              14 non-null     float64\n",
+      " 9   Notes                    0 non-null      float64\n",
+      " 10  Cable Location IDs       16 non-null     object \n",
+      " 11  Port Location IDs        15 non-null     object \n",
+      "dtypes: float64(2), int64(1), object(9)\n",
+      "memory usage: 2.2+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "proj.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9260de3-a61b-4ae3-9ba7-e3bd4b6b22c8",
+   "metadata": {},
+   "source": [
+    "#### Cross-field\n",
+    "- [X] validate FIPS codes to county/state pairs\n",
+    "\n",
+    "* need to use a two-pass geocoding system, first by concatenating \"city, county\" in the locality field, then filling NaN with results using just \"city\"\n",
+    "\n",
+    "Google Geocoder gets confused when cities and counties within the same state share names (Albany, NY and Albany County, NY, and Houston, TX vs Houston County, TX). The geocoder default behavior seems to return the higher level of government. This messes up some of the `geocoded_locality_type` results, and occasionally messes up the FIPS when the identically-named city and county are not colocated. One way to fix this is to use the two-pass geocoding system described above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "4cc6d9c3-0d33-461f-b0e6-fd6fce0bab66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dbcp.transform.helpers import add_county_fips_with_backup_geocoding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "e71f1ebe-1351-420a-9c3f-d9204d3fed3e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geocoded = add_county_fips_with_backup_geocoding(locs[['City', 'State']], state_col='State', locality_col='City')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "55ed56fa-a67b-4fcf-9aa3-30bde2810168",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geocoded = geocoded.join(locs[['City', 'State', 'County', 'County FIPS']].add_prefix('raw_'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "df2cfbe9-5ee0-440c-8c51-ff5388d07e98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for county_col in ['raw_County', 'geocoded_containing_county']:\n",
+    "    geocoded.loc[: ,county_col] = geocoded.loc[: ,county_col].str.replace('County', '').str.strip()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "5270823a-5bb6-4f34-b638-73bec1066b06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geocoded.loc[:, 'raw_County FIPS'] = geocoded['raw_County FIPS'].astype(pd.Int32Dtype()).astype(pd.StringDtype()).str.zfill(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "27dfaeb3-d9c3-4900-b0fe-a872110360a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fips_not_equal = geocoded['raw_County FIPS'].ne(geocoded['county_id_fips']).fillna(True)\n",
+    "county_not_equal = geocoded['raw_County'].ne(geocoded['geocoded_containing_county']).fillna(True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "28f95c55-9cd3-4bde-8746-ef948bc15091",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>City</th>\n",
+       "      <th>State</th>\n",
+       "      <th>state_id_fips</th>\n",
+       "      <th>county_id_fips</th>\n",
+       "      <th>geocoded_locality_name</th>\n",
+       "      <th>geocoded_locality_type</th>\n",
+       "      <th>geocoded_containing_county</th>\n",
+       "      <th>raw_City</th>\n",
+       "      <th>raw_State</th>\n",
+       "      <th>raw_County</th>\n",
+       "      <th>raw_County FIPS</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>location_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>Hampton Roads</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>51</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>Hampton Roads</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>Houston</td>\n",
+       "      <td>TX</td>\n",
+       "      <td>48</td>\n",
+       "      <td>48225</td>\n",
+       "      <td>Houston</td>\n",
+       "      <td>county</td>\n",
+       "      <td>Houston</td>\n",
+       "      <td>Houston</td>\n",
+       "      <td>TX</td>\n",
+       "      <td>Harris</td>\n",
+       "      <td>48201</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                      City State state_id_fips county_id_fips geocoded_locality_name geocoded_locality_type geocoded_containing_county       raw_City raw_State raw_County raw_County FIPS\n",
+       "location_id                                                                                                                                                                               \n",
+       "20           Hampton Roads    VA            51           <NA>                                                                           Hampton Roads        VA        NaN            <NA>\n",
+       "21                 Houston    TX            48          48225                Houston                 county                    Houston        Houston        TX     Harris           48201"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "geocoded[fips_not_equal]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "2aa3280a-7559-448d-8e58-ca0969ca06e1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>City</th>\n",
+       "      <th>State</th>\n",
+       "      <th>state_id_fips</th>\n",
+       "      <th>county_id_fips</th>\n",
+       "      <th>geocoded_locality_name</th>\n",
+       "      <th>geocoded_locality_type</th>\n",
+       "      <th>geocoded_containing_county</th>\n",
+       "      <th>raw_City</th>\n",
+       "      <th>raw_State</th>\n",
+       "      <th>raw_County</th>\n",
+       "      <th>raw_County FIPS</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>location_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>Brooklyn</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>36</td>\n",
+       "      <td>36047</td>\n",
+       "      <td>Brooklyn</td>\n",
+       "      <td>county</td>\n",
+       "      <td>Brooklyn</td>\n",
+       "      <td>Brooklyn</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>Kings</td>\n",
+       "      <td>36047</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>Hampton Roads</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>51</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>Hampton Roads</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>Houston</td>\n",
+       "      <td>TX</td>\n",
+       "      <td>48</td>\n",
+       "      <td>48225</td>\n",
+       "      <td>Houston</td>\n",
+       "      <td>county</td>\n",
+       "      <td>Houston</td>\n",
+       "      <td>Houston</td>\n",
+       "      <td>TX</td>\n",
+       "      <td>Harris</td>\n",
+       "      <td>48201</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38</th>\n",
+       "      <td>Portsmouth</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>51</td>\n",
+       "      <td>51740</td>\n",
+       "      <td>Portsmouth</td>\n",
+       "      <td>county</td>\n",
+       "      <td>Portsmouth</td>\n",
+       "      <td>Portsmouth</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>Portsmouth City</td>\n",
+       "      <td>51740</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>47</th>\n",
+       "      <td>Staten Island</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>36</td>\n",
+       "      <td>36085</td>\n",
+       "      <td>Staten Island</td>\n",
+       "      <td>county</td>\n",
+       "      <td>Staten Island</td>\n",
+       "      <td>Staten Island</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>Richmond</td>\n",
+       "      <td>36085</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49</th>\n",
+       "      <td>Virginia Beach</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>51</td>\n",
+       "      <td>51810</td>\n",
+       "      <td>Virginia Beach</td>\n",
+       "      <td>county</td>\n",
+       "      <td>Virginia Beach</td>\n",
+       "      <td>Virginia Beach</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>Virginia Beach City</td>\n",
+       "      <td>51810</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                       City State state_id_fips county_id_fips geocoded_locality_name geocoded_locality_type geocoded_containing_county        raw_City raw_State           raw_County raw_County FIPS\n",
+       "location_id                                                                                                                                                                                           \n",
+       "8                  Brooklyn    NY            36          36047               Brooklyn                 county                   Brooklyn        Brooklyn        NY                Kings           36047\n",
+       "20            Hampton Roads    VA            51           <NA>                                                                            Hampton Roads        VA                  NaN            <NA>\n",
+       "21                  Houston    TX            48          48225                Houston                 county                    Houston         Houston        TX               Harris           48201\n",
+       "38               Portsmouth    VA            51          51740             Portsmouth                 county                 Portsmouth      Portsmouth        VA      Portsmouth City           51740\n",
+       "47            Staten Island    NY            36          36085          Staten Island                 county              Staten Island   Staten Island        NY             Richmond           36085\n",
+       "49           Virginia Beach    VA            51          51810         Virginia Beach                 county             Virginia Beach  Virginia Beach        VA  Virginia Beach City           51810"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "geocoded[county_not_equal]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "935a95da-1c3f-4d4f-96be-2bb24fb8ffb6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "houston_test = add_county_fips_with_backup_geocoding(pd.DataFrame({'state': ['TX', 'TX'], 'county': ['city of Houston', 'houston']}))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "e29b7672-842a-434b-beea-fd637ae5997e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>state</th>\n",
+       "      <th>county</th>\n",
+       "      <th>state_id_fips</th>\n",
+       "      <th>county_id_fips</th>\n",
+       "      <th>geocoded_locality_name</th>\n",
+       "      <th>geocoded_locality_type</th>\n",
+       "      <th>geocoded_containing_county</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>TX</td>\n",
+       "      <td>city of Houston</td>\n",
+       "      <td>48</td>\n",
+       "      <td>48201</td>\n",
+       "      <td>Houston</td>\n",
+       "      <td>city</td>\n",
+       "      <td>Harris County</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>TX</td>\n",
+       "      <td>houston</td>\n",
+       "      <td>48</td>\n",
+       "      <td>48225</td>\n",
+       "      <td>houston</td>\n",
+       "      <td>county</td>\n",
+       "      <td>houston</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  state           county state_id_fips county_id_fips geocoded_locality_name geocoded_locality_type geocoded_containing_county\n",
+       "0    TX  city of Houston            48          48201                Houston                   city              Harris County\n",
+       "1    TX          houston            48          48225                houston                 county                    houston"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "houston_test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99f3d830-1354-475a-9714-c4524d9b0287",
+   "metadata": {},
+   "source": [
+    "Idea: try concatenating county name in with the city/state pair and geocoding that."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "d1a4efc8-2fc2-41d4-a6b4-76859360b675",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "locs['concat'] = locs['City'] + ', ' + locs['County']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "82e63de4-4f0e-48d5-a841-80dce32d2636",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geo2 = add_county_fips_with_backup_geocoding(locs[['concat', 'State']], state_col='State', locality_col='concat')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "6a5b70af-9644-4f89-ae7e-e98b22415e9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geo2 = geo2.join(locs[['City', 'State', 'County', 'County FIPS']].add_prefix('raw_'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "5026dd3a-f291-4963-a832-84cffb8f38c0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['concat', 'State', 'state_id_fips', 'county_id_fips', 'geocoded_locality_name', 'geocoded_locality_type', 'geocoded_containing_county', 'raw_City', 'raw_State', 'raw_County', 'raw_County FIPS'], dtype='object')"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "geo2.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "43c81422-0076-4b2d-bf7a-60e5b6cb205a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for county_col in ['raw_County', 'geocoded_containing_county']:\n",
+    "    geo2.loc[: ,county_col] = geo2.loc[: ,county_col].str.replace('County', '').str.strip()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "671cd6a7-5014-4c78-9716-72007fe99282",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geo2.loc[:, 'raw_County FIPS'] = geo2['raw_County FIPS'].astype(pd.Int32Dtype()).astype(pd.StringDtype()).str.zfill(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "460996c3-5f94-44f6-a2c7-cec367cf7b93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fips_not_equal2 = geo2['raw_County FIPS'].ne(geo2['county_id_fips']).fillna(True)\n",
+    "county_not_equal2 = geo2['raw_County'].ne(geo2['geocoded_containing_county']).fillna(True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "1d16f1c0-4a44-4ff3-a3d3-e3316f65dd8e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>concat</th>\n",
+       "      <th>State</th>\n",
+       "      <th>state_id_fips</th>\n",
+       "      <th>county_id_fips</th>\n",
+       "      <th>geocoded_locality_name</th>\n",
+       "      <th>geocoded_locality_type</th>\n",
+       "      <th>geocoded_containing_county</th>\n",
+       "      <th>raw_City</th>\n",
+       "      <th>raw_State</th>\n",
+       "      <th>raw_County</th>\n",
+       "      <th>raw_County FIPS</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>location_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>51</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>VA</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>Hampton Roads</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38</th>\n",
+       "      <td>Portsmouth, Portsmouth City</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>51</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>Portsmouth Trail</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>Portsmouth</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>Portsmouth City</td>\n",
+       "      <td>51740</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49</th>\n",
+       "      <td>Virginia Beach, Virginia Beach City</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>51</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>Virginia Beach</td>\n",
+       "      <td>city</td>\n",
+       "      <td>Virginia Beach, Virginia Beach City</td>\n",
+       "      <td>Virginia Beach</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>Virginia Beach City</td>\n",
+       "      <td>51810</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                          concat State state_id_fips county_id_fips geocoded_locality_name geocoded_locality_type           geocoded_containing_county        raw_City raw_State           raw_County raw_County FIPS\n",
+       "location_id                                                                                                                                                                                                                          \n",
+       "20                                           NaN    VA            51           <NA>                     VA                                                               Hampton Roads        VA                  NaN            <NA>\n",
+       "38                   Portsmouth, Portsmouth City    VA            51           <NA>       Portsmouth Trail                                                                  Portsmouth        VA      Portsmouth City           51740\n",
+       "49           Virginia Beach, Virginia Beach City    VA            51           <NA>         Virginia Beach                   city  Virginia Beach, Virginia Beach City  Virginia Beach        VA  Virginia Beach City           51810"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "geo2[fips_not_equal2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "f19ae9c8-c3db-49b3-91a7-156d2a365078",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>concat</th>\n",
+       "      <th>State</th>\n",
+       "      <th>state_id_fips</th>\n",
+       "      <th>county_id_fips</th>\n",
+       "      <th>geocoded_locality_name</th>\n",
+       "      <th>geocoded_locality_type</th>\n",
+       "      <th>geocoded_containing_county</th>\n",
+       "      <th>raw_City</th>\n",
+       "      <th>raw_State</th>\n",
+       "      <th>raw_County</th>\n",
+       "      <th>raw_County FIPS</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>location_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>51</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>VA</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>Hampton Roads</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38</th>\n",
+       "      <td>Portsmouth, Portsmouth City</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>51</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>Portsmouth Trail</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>Portsmouth</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>Portsmouth City</td>\n",
+       "      <td>51740</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49</th>\n",
+       "      <td>Virginia Beach, Virginia Beach City</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>51</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>Virginia Beach</td>\n",
+       "      <td>city</td>\n",
+       "      <td>Virginia Beach, Virginia Beach City</td>\n",
+       "      <td>Virginia Beach</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>Virginia Beach City</td>\n",
+       "      <td>51810</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                          concat State state_id_fips county_id_fips geocoded_locality_name geocoded_locality_type           geocoded_containing_county        raw_City raw_State           raw_County raw_County FIPS\n",
+       "location_id                                                                                                                                                                                                                          \n",
+       "20                                           NaN    VA            51           <NA>                     VA                                                               Hampton Roads        VA                  NaN            <NA>\n",
+       "38                   Portsmouth, Portsmouth City    VA            51           <NA>       Portsmouth Trail                                                                  Portsmouth        VA      Portsmouth City           51740\n",
+       "49           Virginia Beach, Virginia Beach City    VA            51           <NA>         Virginia Beach                   city  Virginia Beach, Virginia Beach City  Virginia Beach        VA  Virginia Beach City           51810"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "geo2[county_not_equal2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd8bef7f-27f1-45fe-8158-2b828259ee28",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Consistency\n",
+    "Locations:\n",
+    "- [ ] Check FIPS codes vs master table\n",
+    "- [X] Geocode names to ensure consistency\n",
+    "- [X] ensure foreign key relationships hold between projects and locations\n",
+    "    - [x] projects cable landings are in locations\n",
+    "    - [X] projects port locations are in locations\n",
+    "    - [x] locations cable landing are in projects\n",
+    "    - [X] locations assembly/manufacturing are in projects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "accf9ed8-8b4e-4323-b0bb-8b7fd29153ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_association_table(ser: pd.Series, name='id') -> pd.Series:\n",
+    "    expanded = ser.str.split(',', expand=True)\n",
+    "    return expanded.melt(value_vars=expanded.columns, value_name=name, ignore_index=False).dropna().loc[:,name].str.strip().astype(int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "c5d9e3c7-1d1f-4fd4-b32a-87aa512aadac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "locations_to_landings = pd.MultiIndex.from_frame(\n",
+    "    make_association_table(locs['Cable project IDs'], name='project_id')\n",
+    "    .reset_index()\n",
+    "    .sort_values(['location_id', 'project_id'])\n",
+    "    [['location_id', 'project_id']]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "72fc1f1d-98f6-4bb9-8ca3-e316e9c9c524",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "landing_to_locations = pd.MultiIndex.from_frame(\n",
+    "    make_association_table(proj['Cable Location IDs'], name='location_id')\n",
+    "    .reset_index()\n",
+    "    .sort_values(['location_id', 'project_id'])\n",
+    "    [['location_id', 'project_id']]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "638d3890-16e4-43fc-b9c0-4903b044088d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert locations_to_landings.symmetric_difference(landing_to_locations).empty"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "af161e3f-857c-40e8-8ef9-4a16a21c3303",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "locations_to_ports = pd.MultiIndex.from_frame(\n",
+    "    make_association_table(locs['assembly/manufac project IDs'], name='project_id')\n",
+    "    .reset_index()\n",
+    "    .sort_values(['location_id', 'project_id'])\n",
+    "    [['location_id', 'project_id']]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "15bec418-f218-4897-b187-22f61796afbe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ports_to_locations = pd.MultiIndex.from_frame(\n",
+    "    make_association_table(proj['Port Location IDs'], name='location_id')\n",
+    "    .reset_index()\n",
+    "    .sort_values(['location_id', 'project_id'])\n",
+    "    [['location_id', 'project_id']]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "id": "98e0efb5-8f35-4485-9014-fe255be33b45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert locations_to_ports.symmetric_difference(ports_to_locations).empty"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-catalystcoop.pudl>=0.5
+catalystcoop.pudl~=0.6.0
 psycopg2~=2.9.3
 pytest~=6.2.5
 tqdm~=4.62.3

--- a/src/dbcp/__init__.py
+++ b/src/dbcp/__init__.py
@@ -12,6 +12,7 @@ import dbcp.extract.lbnl_iso_queue_2021  # noqa: F401
 import dbcp.extract.local_opposition  # noqa: F401
 import dbcp.extract.ncsl_state_permitting  # noqa: F401
 import dbcp.extract.nrel_wind_solar_ordinances  # noqa: F401
+import dbcp.extract.offshore_wind  # noqa: F401
 import dbcp.helpers  # noqa: F401
 import dbcp.transform.eip_infrastructure  # noqa: F401
 import dbcp.transform.fips_tables  # noqa: F401
@@ -20,3 +21,4 @@ import dbcp.transform.lbnl_iso_queue_2021  # noqa: F401
 import dbcp.transform.local_opposition  # noqa: F401
 import dbcp.transform.ncsl_state_permitting  # noqa: F401
 import dbcp.transform.nrel_wind_solar_ordinances  # noqa: F401
+import dbcp.transform.offshore_wind  # noqa: F401

--- a/src/dbcp/etl.py
+++ b/src/dbcp/etl.py
@@ -137,6 +137,18 @@ def etl_nrel_ordinances() -> dict[str, pd.DataFrame]:
     return nrel_transformed_dfs
 
 
+def etl_offshore_wind() -> dict[str, pd.DataFrame]:
+    """ETL manually curated offshore wind data."""
+    locations_path = Path("/app/data/raw/offshore_wind_locations.csv")
+    projects_path = Path("/app/data/raw/offshore_wind_projects.csv")
+    raw_offshore_dfs = dbcp.extract.offshore_wind.extract(
+        locations_path=locations_path, projects_path=projects_path
+    )
+    offshore_transformed_dfs = dbcp.transform.offshore_wind.transform(raw_offshore_dfs)
+
+    return offshore_transformed_dfs
+
+
 def etl(args):
     """Run dbc ETL."""
     # Setup postgres
@@ -148,6 +160,7 @@ def etl(args):
     GEOCODER_CACHE.reduce_size()
 
     etl_funcs = {
+        "offshore_wind": etl_offshore_wind,
         "justice40_tracts": etl_justice40,
         "nrel_wind_solar_ordinances": etl_nrel_ordinances,
         "eip_infrastructure": etl_eip_infrastructure,

--- a/src/dbcp/extract/offshore_wind.py
+++ b/src/dbcp/extract/offshore_wind.py
@@ -1,0 +1,47 @@
+"""Extract offshore wind location and project data from CSVs extracted from Airtable."""
+
+from pathlib import Path
+
+import pandas as pd
+
+
+def extract(*, locations_path: Path, projects_path: Path) -> dict[str, pd.DataFrame]:
+    """Extract offshore wind location and project data.
+
+    Args:
+        locations_path (Path): path to CSV file
+        projects_path (Path): path to CSV file
+
+    Returns:
+        dict[str, pd.DataFrame]: raw data, with keys "offshore_locations" and "offshore_projects"
+    """
+    proj_dtypes = {
+        "Name": pd.StringDtype(),
+        "Recipient State": pd.StringDtype(),
+        "Developer": pd.StringDtype(),
+        "Status": pd.StringDtype(),
+        "Proposed cable landing": pd.StringDtype(),
+        "County of Cable Landing": pd.StringDtype(),
+        "Port Locations": pd.StringDtype(),
+        "Size (megawatts)": pd.Float32Dtype(),
+        "Online date": pd.Int16Dtype(),
+        "Notes": pd.StringDtype(),
+        "Cable Location IDs": pd.StringDtype(),
+        "Port Location IDs": pd.StringDtype(),
+    }
+    locs_dtypes = {
+        "City": pd.StringDtype(),
+        "State": pd.StringDtype(),
+        "County": pd.StringDtype(),
+        "County FIPS": pd.StringDtype(),
+        "Why of interest?": pd.StringDtype(),
+        "Priority": pd.StringDtype(),
+        "Cable landing(s)": pd.StringDtype(),
+        "Assembly/manufacturing": pd.StringDtype(),
+        "Notes": pd.StringDtype(),
+        "Cable project ID": pd.StringDtype(),
+        "assembly/manufac project ID": pd.StringDtype(),
+    }
+    proj = pd.read_csv(projects_path, index_col="project_id", dtype=proj_dtypes)
+    locs = pd.read_csv(locations_path, index_col="location_id", dtype=locs_dtypes)
+    return {"offshore_locations": locs, "offshore_projects": proj}

--- a/src/dbcp/metadata/data_mart.py
+++ b/src/dbcp/metadata/data_mart.py
@@ -146,6 +146,8 @@ counties_wide_format = Table(
     Column("n_tracts_unemployment_and_low_high_school", Integer),
     Column("n_tracts_unemployment_less_than_high_school_islands", Integer),
     Column("n_tracts_wastewater_low_income_not_students", Integer),
+    Column("offshore_wind_capacity_mw_via_ports", Float),
+    Column("offshore_wind_interest_type", String),
     schema=schema,
 )
 

--- a/src/dbcp/metadata/data_warehouse.py
+++ b/src/dbcp/metadata/data_warehouse.py
@@ -613,3 +613,54 @@ nrel_local_ordinances = Table(
     Column("geocoded_containing_county", String),
     schema=schema,
 )
+
+
+##########################
+# Offshore Wind Projects #
+##########################
+
+
+offshore_wind_projects = Table(
+    "offshore_wind_projects",
+    metadata,
+    Column("project_id", Integer, primary_key=True),
+    Column("name", String),
+    Column("recipient_state", String),
+    Column("developer", String),
+    Column("status", String),
+    Column("capacity_mw", Float),
+    Column("proposed_completion_year", Integer),
+    Column("notes", String),
+    schema=schema,
+)
+offshore_wind_locations = Table(
+    "offshore_wind_locations",
+    metadata,
+    Column("location_id", Integer, primary_key=True),
+    Column("raw_city", String),
+    Column("raw_state_abbrev", String),
+    Column("raw_county", String),
+    Column("raw_county_fips", String),
+    Column("why_of_interest", String),
+    Column("priority", String),
+    Column("notes", String),
+    Column("county_id_fips", String),
+    Column("geocoded_locality_name", String),
+    Column("geocoded_locality_type", String),
+    Column("geocoded_containing_county", String),
+    schema=schema,
+)
+offshore_wind_cable_landing_association = Table(
+    "offshore_wind_cable_landing_association",
+    metadata,
+    Column("location_id", Integer, primary_key=True),
+    Column("project_id", Integer, primary_key=True),
+    schema=schema,
+)
+offshore_wind_port_association = Table(
+    "offshore_wind_port_association",
+    metadata,
+    Column("location_id", Integer, primary_key=True),
+    Column("project_id", Integer, primary_key=True),
+    schema=schema,
+)

--- a/src/dbcp/transform/offshore_wind.py
+++ b/src/dbcp/transform/offshore_wind.py
@@ -1,0 +1,200 @@
+"""Transform and normalize offshore wind location and project data from Airtable."""
+
+import pandas as pd
+
+from dbcp.transform.helpers import add_county_fips_with_backup_geocoding
+from pudl.helpers import simplify_columns
+
+
+def _transform_columns(
+    raw_df: pd.DataFrame, *, cols_to_drop: list[str], rename_dict: dict[str, str]
+) -> None:
+    simplify_columns(raw_df)
+    raw_df.drop(columns=cols_to_drop, inplace=True)
+    raw_df.rename(columns=rename_dict, inplace=True)
+    return
+
+
+def _association_table_from_csv_array(ser: pd.Series, name="id") -> pd.Series:
+    """Convert a series of CSV string arrays to a long-format association table.
+
+    Example input:
+    pd.Series(['1,2', '1,3,7'], index=['a', 'b'])
+
+    Example Output (note: dtype is still string):
+    'a'  '1'
+    'a'  '2'
+    'b'  '1'
+    'b'  '3'
+    'b'  '7'
+    """
+    expanded = ser.str.split(",", expand=True)
+    out = (
+        expanded.melt(value_vars=expanded.columns, value_name=name, ignore_index=False)
+        .dropna()
+        .loc[:, name]
+        .str.strip()
+    )
+    return out
+
+
+def _id_association_table_from_csv_array(
+    ser: pd.Series, name="project_id"
+) -> pd.DataFrame:
+    """Special case of _association_table_from_csv_array for the integer ID arrays in this particular dataset."""
+    out = (
+        _association_table_from_csv_array(ser, name=name)
+        .astype(int)
+        .reset_index()
+        .sort_values(["location_id", "project_id"])
+    )
+    return out
+
+
+def _add_geocoded_locations(transformed_locs: pd.DataFrame) -> None:
+    """Standardize place names and fetch county FIPS codes.
+
+    We need to use a two-pass geocoding system because both city and county names are present in the "city" column.
+    The first pass operates on a concatenated "city, county" field, then any NaN results are filled using just "city".
+
+    This is because Google Maps Platform resolves city/county ambiguity by returning the higher level of government.
+    This messes up some of the `geocoded_locality_type` results (Albany, NY is in Albany County, NY). It also
+    occasionally messes up the FIPS when the identically-named city and county are not colocated
+    (Houston, TX is not in Houston County, TX). One way to fix this is to use the two-pass geocoding system used here.
+
+    Args:
+        transformed_locs (pd.DataFrame): locations df after other cleaning has been performed
+    """
+    # this code is ugly and procedural for the sake of making inplace operations.
+    # And all to save copy operations on a dataframe that is... 50 rows lol. Dumb!
+    transformed_locs["city_county"] = (
+        transformed_locs["raw_city"] + ", " + transformed_locs["raw_county"]
+    )
+    first_pass = add_county_fips_with_backup_geocoding(
+        transformed_locs[["city_county", "raw_state_abbrev"]],
+        state_col="raw_state_abbrev",
+        locality_col="city_county",
+    )
+    transformed_locs.drop(columns=["city_county"], inplace=True)
+
+    nan_fips_idx = first_pass["county_id_fips"].isna()
+    second_pass = add_county_fips_with_backup_geocoding(
+        transformed_locs.loc[nan_fips_idx, ["raw_city", "raw_state_abbrev"]],
+        state_col="raw_state_abbrev",
+        locality_col="raw_city",
+    )
+
+    cols_to_fill = [
+        "county_id_fips",
+        "geocoded_locality_name",
+        "geocoded_locality_type",
+        "geocoded_containing_county",
+    ]
+    first_pass.update(second_pass.loc[:, cols_to_fill])
+    transformed_locs.loc[:, cols_to_fill] = first_pass[cols_to_fill]
+    return
+
+
+def _validate_raw_data(raw_dfs: dict[str, pd.DataFrame]) -> None:
+    proj = raw_dfs["offshore_projects"].copy()
+    locs = raw_dfs["offshore_locations"].copy()
+    for df in (proj, locs):
+        assert (
+            not df.eq("").any().any()
+        ), f"Empty strings in df with index {df.index.name}"
+        assert df.index.is_unique, f"Index {df.index.name} is not unique."
+
+    assert proj["Size (megawatts)"].min() > 100, "Found unusually small project."
+    assert proj["Size (megawatts)"].max() < 10_000, "Found unusually large project."
+
+    assert (
+        proj["Recipient State"].str.contains("TBD").sum() == 1
+    ), "More missing recipient states than expected."
+
+    assert (
+        proj["Online date"].min() > 2022
+    ), "Found project with erroneously early online_date."
+    assert (
+        proj["Online date"].max() < 2040
+    ), "Found project with erroneously late online_date."
+
+    # check referential symmetry (should be handled by Airtable, but check anyway)
+    locations_to_landings = pd.MultiIndex.from_frame(
+        _id_association_table_from_csv_array(locs["Cable project IDs"])
+    )
+    landing_to_locations = pd.MultiIndex.from_frame(
+        _id_association_table_from_csv_array(
+            proj["Cable Location IDs"], name="location_id"
+        )[
+            ["location_id", "project_id"]
+        ]  # reorder columns
+    )
+    assert locations_to_landings.symmetric_difference(landing_to_locations).empty
+
+    locations_to_ports = pd.MultiIndex.from_frame(
+        _id_association_table_from_csv_array(locs["assembly/manufac project IDs"])
+    )
+    ports_to_locations = pd.MultiIndex.from_frame(
+        _id_association_table_from_csv_array(
+            proj["Port Location IDs"], name="location_id"
+        )[["location_id", "project_id"]]
+    )
+    assert locations_to_ports.symmetric_difference(ports_to_locations).empty
+
+
+def transform(raw_dfs: dict[str, pd.DataFrame]) -> dict[str, pd.DataFrame]:
+    """Transform offshore wind data."""
+    _validate_raw_data(raw_dfs=raw_dfs)
+    proj = raw_dfs["offshore_projects"].copy()
+    locs = raw_dfs["offshore_locations"].copy()
+    # NOTE: the following column names are not raw names!
+    # They are the results of simplify_columns(), which is called in _transform_columns
+    proj_cols_to_drop = [
+        "proposed_cable_landing",
+        "county_of_cable_landing",
+        "port_locations",
+    ]
+    proj_rename_dict = {
+        "size_megawatts": "capacity_mw",
+        "online_date": "proposed_completion_year",
+    }
+    locs_cols_to_drop = [
+        "cable_landing_s",
+        "assembly_manufacturing",
+    ]
+    locs_rename_dict = {
+        "city": "raw_city",
+        "state": "raw_state_abbrev",
+        "county": "raw_county",
+        "county_fips": "raw_county_fips",
+    }
+    _transform_columns(
+        proj, cols_to_drop=proj_cols_to_drop, rename_dict=proj_rename_dict
+    )
+    _transform_columns(
+        locs, cols_to_drop=locs_cols_to_drop, rename_dict=locs_rename_dict
+    )
+
+    proj.loc[:, "recipient_state"].replace({"TBD": pd.NA}, inplace=True)
+
+    transformed_dfs = {}
+    transformed_dfs[
+        "offshore_wind_cable_landing_association"
+    ] = _id_association_table_from_csv_array(locs["cable_project_ids"])
+    transformed_dfs[
+        "offshore_wind_port_association"
+    ] = _id_association_table_from_csv_array(locs["assembly_manufac_project_ids"])
+    # CSV array fields no longer needed (proj CSV fields could be dropped after _validate_raw_data())
+    locs.drop(
+        columns=["cable_project_ids", "assembly_manufac_project_ids"], inplace=True
+    )
+    proj.drop(columns=["cable_location_ids", "port_location_ids"], inplace=True)
+
+    _add_geocoded_locations(locs)
+    # move index into columns
+    locs.reset_index(inplace=True)
+    proj.reset_index(inplace=True)
+    transformed_dfs["offshore_wind_projects"] = proj
+    transformed_dfs["offshore_wind_locations"] = locs
+
+    return transformed_dfs


### PR DESCRIPTION
This PR integrates offshore wind data manually curated by a consultant. The source data is hosted on Airtable and imported via flat files rather than an API integration.

In the county-level data mart tables, proposed offshore wind data sourced from ISO queues has been replaced with this curated data. For future dashboard integration, the data in the `iso_projects_xxx` data mart tables must also be replaced. This second work component has not been done here.