### PR TITLE
Create a dev BigQuery dataset

### DIFF
--- a/makefile
+++ b/makefile
@@ -7,20 +7,29 @@ shell:
 etl_local:
 	docker compose run --rm app python -m dbcp.cli --etl
 
-etl_bq:
-	docker compose run --rm app python -m dbcp.cli --etl --upload-to-bigquery
-
 data_mart_local:
 	docker compose run --rm app python -m dbcp.cli --data-mart
-
-data_mart_bq:
-	docker compose run --rm app python -m dbcp.cli --data-mart --upload-to-bigquery
 
 all_local:
 	docker compose run --rm app python -m dbcp.cli --data-mart --etl
 
-all_bq:
-	docker compose run --rm app python -m dbcp.cli --data-mart --etl --upload-to-bigquery
+etl_bq_dev:
+	docker compose run --rm app python -m dbcp.cli --etl --upload-to-bigquery --bigquery-env dev
+
+data_mart_bq_dev:
+	docker compose run --rm app python -m dbcp.cli --data-mart --upload-to-bigquery --bigquery-env dev
+
+all_bq_dev:
+	docker compose run --rm app python -m dbcp.cli --data-mart --etl --upload-to-bigquery --bigquery-env dev
+
+etl_bq_prod:
+	docker compose run --rm app python -m dbcp.cli --etl --upload-to-bigquery --bigquery-env prod
+
+data_mart_bq_prod:
+	docker compose run --rm app python -m dbcp.cli --data-mart --upload-to-bigquery --bigquery-env prod
+
+all_bq_prod:
+	docker compose run --rm app python -m dbcp.cli --data-mart --etl --upload-to-bigquery --bigquery-env prod
 
 sql_shell:
 	docker compose run --rm postgres bash -c 'psql -U $$POSTGRES_USER -h $$POSTGRES_HOST $$POSTGRES_DB'

--- a/src/dbcp/cli.py
+++ b/src/dbcp/cli.py
@@ -51,6 +51,12 @@ def parse_command_line():
         help="Loads tables to BigQuery.",
     )
     parser.add_argument(
+        "-bqenv",
+        "--bigquery-env",
+        help="Select which BigQuery environment to load the data to (prod or dev).",
+        default="dev",
+    )
+    parser.add_argument(
         "--loglevel",
         help="Set logging level (DEBUG, INFO, WARNING, ERROR, or CRITICAL).",
         default="INFO",

--- a/src/dbcp/etl.py
+++ b/src/dbcp/etl.py
@@ -231,6 +231,13 @@ def etl(args):
             df.to_csv(output_path / f"{table_name}.csv", index=False)
 
     if args.upload_to_bigquery:
-        dbcp.helpers.upload_schema_to_bigquery("data_warehouse")
+        if args.bigquery_env == "dev":
+            dbcp.helpers.upload_schema_to_bigquery("data_warehouse")
+        elif args.bigquery_env == "prod":
+            dbcp.helpers.upload_schema_to_bigquery("data_warehouse", dev=False)
+        else:
+            raise ValueError(
+                f"{args.bigquery_env} is an invalid BigQuery environment value. Must be: dev or prod."
+            )
 
     logger.info("Sucessfully finished ETL.")


### PR DESCRIPTION
This PR creates two new BQ datasets in GCP project `dbcp-dev-350818`: `data_warehouse_dev` and `data_mart_dev`. These new development datasets will allow us to push changes to BQ without breaking downstream services (google sheets and tableau).

Things I'd like to do when I get back from vacation.
- [ ] Rename our "production" datasets from `data_warehouse` and `data_mart` to `data_warehouse_prod` and `data_mart_prod`. @TrentonBush this will likely require a decent amount of Tableau changes. (We've decided to pass on this for now.)
- [x] Adjust the IAM so the dev datasets are hidden from folks in the `big-query-users` group. I'd like to do this once the `prod` datasets have been renamed and I can test the permissions with a climate partners person.
- [x] Delete the old `deployment-gap-model-dev` gcp project.

I figured this PR can be merged in now and the above issues could be handled in a separate PR.